### PR TITLE
feat: show quota reset time in next trigger preview

### DIFF
--- a/src/view/webview/auto_trigger.css
+++ b/src/view/webview/auto_trigger.css
@@ -609,6 +609,13 @@
     margin: 4px 0;
 }
 
+.at-reset-hint {
+    font-size: 11px;
+    color: var(--vscode-charts-green, #4CAF50);
+    opacity: 0.85;
+    margin-left: 4px;
+}
+
 /* History */
 .at-history-list {
     max-height: 400px;

--- a/src/view/webview/auto_trigger.js
+++ b/src/view/webview/auto_trigger.js
@@ -726,7 +726,8 @@
                 return;
             }
             container.innerHTML = nextRuns.map((date, idx) => {
-                return `<li>${idx + 1}. ${formatDateTime(date)}</li>`;
+                const resetTime = formatResetTime(date);
+                return `<li>${idx + 1}. ${formatDateTime(date)} <span class="at-reset-hint">(resets ${resetTime})</span></li>`;
             }).join('');
             return;
         }
@@ -751,7 +752,8 @@
 
         container.innerHTML = nextRuns.map((iso, idx) => {
             const date = new Date(iso);
-            return `<li>${idx + 1}. ${formatDateTime(date)}</li>`;
+            const resetTime = formatResetTime(date);
+            return `<li>${idx + 1}. ${formatDateTime(date)} <span class="at-reset-hint">(resets ${resetTime})</span></li>`;
         }).join('');
     }
     
@@ -875,6 +877,12 @@
                            'time.thursday', 'time.friday', 'time.saturday'];
             return `${t(dayKeys[date.getDay()])} ${timeStr}`;
         }
+    }
+
+    function formatResetTime(triggerDate) {
+        // Reset time is 5 hours after trigger
+        const resetDate = new Date(triggerDate.getTime() + 5 * 60 * 60 * 1000);
+        return resetDate.toLocaleTimeString(undefined, { hour: '2-digit', minute: '2-digit' });
     }
 
     // ============ 状态更新 ============


### PR DESCRIPTION
Adds reset time display to each trigger time in the "Next Trigger Times" preview.

Example:
- Before: `Tomorrow 09:00 AM`
- After: `Tomorrow 09:00 AM (resets 02:00 PM)`