### PR TITLE
feat: add support for multiple accounts

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "antigravity-cockpit",
-  "version": "1.6.15",
+  "version": "1.7.22",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "antigravity-cockpit",
-      "version": "1.6.15",
+      "version": "1.7.22",
       "dependencies": {
         "cron-parser": "^5.4.0"
       },

--- a/src/auto_trigger/types.ts
+++ b/src/auto_trigger/types.ts
@@ -18,13 +18,26 @@ export interface OAuthCredential {
 }
 
 /**
- * 授权状态
+ * Account info for UI display (multi-account support)
+ */
+export interface AccountInfo {
+    email: string;
+    isActive: boolean;
+    expiresAt?: string;
+}
+
+/**
+ * 授权状态 (supports multiple accounts)
  */
 export interface AuthorizationStatus {
     isAuthorized: boolean;
     email?: string;
     expiresAt?: string;
     lastRefresh?: string;
+    /** All authorized accounts */
+    accounts?: AccountInfo[];
+    /** Currently active account email */
+    activeAccount?: string;
 }
 
 /**
@@ -43,28 +56,28 @@ export type DayOfWeek = 0 | 1 | 2 | 3 | 4 | 5 | 6;  // 0 = Sunday
 export interface ScheduleConfig {
     enabled: boolean;
     repeatMode: ScheduleRepeatMode;
-    
+
     // 每天模式
     dailyTimes?: string[];  // ["07:00", "12:00", "17:00"]
-    
+
     // 每周模式
     weeklyDays?: number[];  // [1, 2, 3, 4, 5] = 工作日 (0 = Sunday)
     weeklyTimes?: string[];
-    
+
     // 间隔模式
     intervalHours?: number;
     intervalStartTime?: string;  // "07:00"
     intervalEndTime?: string;    // "22:00" (可选，不填则全天)
-    
+
     // 高级: 原始 crontab 表达式
     crontab?: string;
-    
+
     /** 选中的模型列表 (用于触发) */
     selectedModels: string[];
-    
+
     /** 配额重置时自动唤醒 */
     wakeOnReset?: boolean;
-    
+
     /** 自定义唤醒词 (默认: "hi") */
     customPrompt?: string;
 }
@@ -111,13 +124,13 @@ export interface AutoTriggerState {
  * Webview 消息类型
  */
 export interface AutoTriggerMessage {
-    type: 
-        | 'auto_trigger_get_state'
-        | 'auto_trigger_start_auth'
-        | 'auto_trigger_revoke_auth'
-        | 'auto_trigger_save_schedule'
-        | 'auto_trigger_test_trigger'
-        | 'auto_trigger_state_update';
+    type:
+    | 'auto_trigger_get_state'
+    | 'auto_trigger_start_auth'
+    | 'auto_trigger_revoke_auth'
+    | 'auto_trigger_save_schedule'
+    | 'auto_trigger_test_trigger'
+    | 'auto_trigger_state_update';
     data?: {
         models?: string[];
         [key: string]: unknown;

--- a/src/shared/translations/en.ts
+++ b/src/shared/translations/en.ts
@@ -54,7 +54,7 @@ export const en = {
     'help.startAntigravity': 'Start Antigravity',
     'help.retry': 'Retry Connection',
     'help.openLogs': 'Open Logs',
-    
+
     // User Profile
     'profile.plan': 'Plan',
     'profile.tier': 'Tier',
@@ -109,7 +109,7 @@ export const en = {
     'grouping.autoGroup': 'Auto Group',
     'grouping.autoGroupHint': 'Recalculate groups based on current quota',
     'grouping.description': 'This mode aggregates models sharing the same quota. Supports renaming, sorting, and status bar sync. Click "Manage Groups" to customize, or toggle "Quota Groups" above to switch back.',
-    
+
     // Custom Grouping
     'customGrouping.title': 'Manage Groups',
     'customGrouping.hint': 'Only models with same quota and reset time can be grouped. Models will be auto-removed from group when quota changes cause inconsistency.',
@@ -370,6 +370,20 @@ export const en = {
     'autoTrigger.customPrompt': 'Custom Wake Word',
     'autoTrigger.customPromptPlaceholder': 'Default: hi',
     'autoTrigger.customPromptHint': 'Message sent to AI for wake-up, leave empty to use default "hi".',
+
+    // Multi-Account
+    'autoTrigger.accountList': 'Authorized Accounts',
+    'autoTrigger.addAccount': 'Add Account',
+    'autoTrigger.removeAccount': 'Remove',
+    'autoTrigger.switchAccount': 'Switch',
+    'autoTrigger.accountActive': 'Active',
+    'autoTrigger.noActiveAccount': 'No active account selected',
+    'autoTrigger.confirmRemove': 'Are you sure you want to remove this account?',
+    'autoTrigger.confirmRemoveTitle': 'Remove Account',
+    'autoTrigger.accountAdded': 'Account added: {email}',
+    'autoTrigger.accountRemoved': 'Account removed: {email}',
+    'autoTrigger.accountSwitched': 'Switched to account: {email}',
+    'autoTrigger.accountDuplicate': 'Account {email} already exists',
 
     // Announcement
     'announcement.title': 'Notifications',

--- a/src/shared/translations/zh-cn.ts
+++ b/src/shared/translations/zh-cn.ts
@@ -109,7 +109,7 @@ export const zhCN = {
     'grouping.autoGroup': '自动分组',
     'grouping.autoGroupHint': '根据当前配额重新计算分组',
     'grouping.description': '此模式将共享配额的模型聚合展示，支持重命名、排序并同步至状态栏。您可以点击右侧"分组管理"自定义分组，或点击上方「配额分组」切换回全部模型视图。',
-    
+
     // Custom Grouping
     'customGrouping.title': '分组管理',
     'customGrouping.hint': '只有配额和重置时间相同的模型可归入同一分组。当配额变化导致不一致时，不符合的模型会被自动移出分组。',
@@ -370,6 +370,20 @@ export const zhCN = {
     'autoTrigger.modeQuotaReset': '配额重置自动唤醒',
     'autoTrigger.modeQuotaResetHint': '检测到配额恢复满额时自动唤醒一次',
     'autoTrigger.crontabLabel': 'Crontab 表达式',
+
+    // Multi-Account 多账号管理
+    'autoTrigger.accountList': '已授权账号',
+    'autoTrigger.addAccount': '添加账号',
+    'autoTrigger.removeAccount': '移除',
+    'autoTrigger.switchAccount': '切换',
+    'autoTrigger.accountActive': '当前使用',
+    'autoTrigger.noActiveAccount': '未选择活跃账号',
+    'autoTrigger.confirmRemove': '确定要移除此账号吗？',
+    'autoTrigger.confirmRemoveTitle': '移除账号',
+    'autoTrigger.accountAdded': '已添加账号: {email}',
+    'autoTrigger.accountRemoved': '已移除账号: {email}',
+    'autoTrigger.accountSwitched': '已切换至账号: {email}',
+    'autoTrigger.accountDuplicate': '账号 {email} 已存在',
 
     // Announcement
     'announcement.title': '消息通知',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -142,7 +142,7 @@ export interface PlanInfo {
     planName: string;
     monthlyPromptCredits: number;
     monthlyFlowCredits: number;
-    
+
     // 功能开关
     browserEnabled?: boolean;
     knowledgeBaseEnabled?: boolean;
@@ -156,7 +156,7 @@ export interface PlanInfo {
     canCustomizeAppIcon?: boolean;
     cascadeCanAutoRunCommands?: boolean;
     canAllowCascadeInBackground?: boolean;
-    
+
     // 限制配置
     maxNumChatInputTokens?: string | number;
     maxNumPremiumChatMessages?: string | number;
@@ -164,10 +164,10 @@ export interface PlanInfo {
     maxNumPinnedContextItems?: string | number;
     maxLocalIndexSize?: string | number;
     monthlyFlexCreditPurchaseAmount?: number;
-    
+
     // 团队配置
     defaultTeamConfig?: DefaultTeamConfig;
-    
+
     /** 扩展字段 - 支持 API 返回的其他属性 */
     [key: string]: string | number | boolean | object | undefined;
 }
@@ -304,7 +304,7 @@ export interface UserInfo {
 // ============ UI 相关类型 ============
 
 /** Webview 消息类型 */
-export type WebviewMessageType = 
+export type WebviewMessageType =
     | 'init'
     | 'refresh'
     | 'togglePin'
@@ -338,6 +338,9 @@ export type WebviewMessageType =
     | 'tabChanged'
     | 'autoTrigger.authorize'
     | 'autoTrigger.revoke'
+    | 'autoTrigger.addAccount'
+    | 'autoTrigger.removeAccount'
+    | 'autoTrigger.switchAccount'
     | 'autoTrigger.saveSchedule'
     | 'autoTrigger.test'
     | 'autoTrigger.validateCrontab'
@@ -399,6 +402,8 @@ export interface WebviewMessage {
     crontab?: string;
     /** 手动测试模型列表 (autoTrigger.test) */
     models?: string[];
+    /** 账号邮箱 (autoTrigger.removeAccount, autoTrigger.switchAccount) */
+    email?: string;
     // Announcements
     /** 公告 ID (announcement.markAsRead) */
     id?: string;

--- a/src/view/webview/auto_trigger.css
+++ b/src/view/webview/auto_trigger.css
@@ -814,6 +814,98 @@
 }
 
 /* ========================================
+   Multi-Account Authorization
+   ======================================== */
+
+.at-auth-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 12px;
+}
+
+.at-auth-title {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--vscode-foreground);
+}
+
+.at-account-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+}
+
+.at-account-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    background: var(--vscode-input-background);
+    border: 1px solid var(--vscode-input-border);
+    border-radius: 6px;
+    transition: all 0.2s ease;
+}
+
+.at-account-item:hover {
+    border-color: var(--vscode-button-background);
+}
+
+.at-account-item.active {
+    border-color: var(--vscode-charts-green);
+    background: rgba(76, 175, 80, 0.08);
+}
+
+.at-account-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+}
+
+.at-account-icon {
+    font-size: 18px;
+    flex-shrink: 0;
+}
+
+.at-account-email {
+    font-size: 13px;
+    color: var(--vscode-foreground);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.at-account-badge {
+    font-size: 10px;
+    padding: 2px 8px;
+    background: rgba(76, 175, 80, 0.2);
+    color: var(--vscode-charts-green);
+    border-radius: 10px;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.at-account-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+    margin-left: 12px;
+}
+
+/* Update auth row for multi-account layout */
+.at-auth-row {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+}
+
+.at-auth-row .at-auth-info {
+    gap: 10px;
+}
+
+/* ========================================
    Schedule Section
    ======================================== */
 

--- a/src/view/webview/auto_trigger.js
+++ b/src/view/webview/auto_trigger.js
@@ -3,7 +3,7 @@
  * 自动触发功能的前端逻辑 - 紧凑布局版本
  */
 
-(function() {
+(function () {
     'use strict';
 
     // 获取 VS Code API
@@ -32,7 +32,7 @@
     ]);
     let selectedModels = [];  // 从 state.schedule.selectedModels 获取
     let testSelectedModels = [];
-    
+
     // 配置状态
     let configEnabled = false;
     let configTriggerMode = 'scheduled';
@@ -99,7 +99,7 @@
             configEnabled = e.target.checked;
             updateConfigAvailability();
         });
-        
+
         // 唤醒方式
         document.getElementById('at-trigger-mode-list')?.addEventListener('click', (e) => {
             const target = e.target.closest('.at-segment-btn');
@@ -185,7 +185,7 @@
                 }
             }
         });
-        
+
         // Crontab 输入监听
         document.getElementById('at-crontab-input')?.addEventListener('input', () => {
             if (configTriggerMode === 'crontab') {
@@ -224,10 +224,10 @@
     function openTestModal() {
         // 获取可用模型的 ID 列表
         const availableIds = availableModels.map(m => m.id);
-        
+
         // 从 selectedModels 中过滤，只保留在可用模型列表中的
         const validSelected = selectedModels.filter(id => availableIds.includes(id));
-        
+
         if (validSelected.length > 0) {
             testSelectedModels = [...validSelected];
         } else if (availableModels.length > 0) {
@@ -236,7 +236,7 @@
         } else {
             testSelectedModels = [];
         }
-        
+
         renderTestModels();
         document.getElementById('at-test-modal')?.classList.remove('hidden');
     }
@@ -271,7 +271,7 @@
 
     function loadConfigFromState() {
         if (!currentState?.schedule) return;
-        
+
         const s = currentState.schedule;
         configEnabled = s.enabled || false;
         configMode = s.repeatMode || 'daily';
@@ -287,7 +287,7 @@
         document.getElementById('at-mode-select').value = configMode;
         document.getElementById('at-interval-hours').value = configIntervalHours;
         document.getElementById('at-interval-start').value = configIntervalStart;
-        
+
         // 唤醒方式
         if (s.wakeOnReset) {
             configTriggerMode = 'quota_reset';
@@ -297,13 +297,13 @@
             configTriggerMode = 'scheduled';
         }
         updateTriggerModeSelection();
-        
+
         // 自定义唤醒词
         const customPromptInput = document.getElementById('at-custom-prompt');
         if (customPromptInput) {
             customPromptInput.value = s.customPrompt || '';
         }
-        
+
         // 恢复 Crontab
         const crontabInput = document.getElementById('at-crontab-input');
         if (crontabInput) {
@@ -325,7 +325,7 @@
             }
             return;
         }
-        
+
         const config = {
             enabled: configEnabled,
             repeatMode: configMode,
@@ -358,7 +358,7 @@
             .map(el => el.dataset.model)
             .filter(Boolean);
     }
-    
+
     function runTest() {
         if (isTestRunning) return;
 
@@ -366,16 +366,16 @@
         if (pickedModels.length > 0) {
             testSelectedModels = pickedModels;
         }
-        
+
         if (testSelectedModels.length === 0) {
             // 使用第一个可用模型作为默认
             const defaultModel = availableModels.length > 0 ? availableModels[0].id : 'gemini-3-flash';
             testSelectedModels = [defaultModel];
         }
-        
+
         // 获取自定义唤醒词
         const customPrompt = document.getElementById('at-test-custom-prompt')?.value.trim() || undefined;
-        
+
         // 设置加载状态
         isTestRunning = true;
         const runBtn = document.getElementById('at-test-run');
@@ -383,24 +383,24 @@
             runBtn.disabled = true;
             runBtn.innerHTML = `<span class="at-spinner"></span> ${t('autoTrigger.testing')}`;
         }
-        
+
         // 关闭弹窗
         closeTestModal();
-        
+
         // 显示状态提示
         showTestingStatus();
-        
+
         vscode.postMessage({
             command: 'autoTrigger.test',
             models: [...testSelectedModels],
             customPrompt: customPrompt,
         });
     }
-    
+
     function showTestingStatus() {
         const statusCard = document.getElementById('at-status-card');
         if (!statusCard) return;
-        
+
         // 添加测试中提示
         let testingBanner = document.getElementById('at-testing-banner');
         if (!testingBanner) {
@@ -412,13 +412,13 @@
         testingBanner.innerHTML = `<span class="at-spinner"></span> ${t('autoTrigger.testingPleaseWait')}`;
         testingBanner.classList.remove('hidden');
     }
-    
+
     function hideTestingStatus() {
         const testingBanner = document.getElementById('at-testing-banner');
         if (testingBanner) {
             testingBanner.classList.add('hidden');
         }
-        
+
         // 重置按钮状态
         isTestRunning = false;
         const runBtn = document.getElementById('at-test-run');
@@ -642,7 +642,7 @@
         if (!container) return;
 
         const triggers = currentState?.recentTriggers || [];
-        
+
         if (triggers.length === 0) {
             container.innerHTML = `<div class="at-no-data">${t('autoTrigger.noHistory')}</div>`;
             return;
@@ -653,7 +653,7 @@
             const timeStr = date.toLocaleString();
             const icon = trigger.success ? '✅' : '❌';
             const statusText = trigger.success ? t('autoTrigger.success') : t('autoTrigger.failed');
-            
+
             // 显示请求内容和响应
             let contentHtml = '';
             if (trigger.prompt) {
@@ -682,7 +682,7 @@
                 }
             }
             const typeBadge = `<span class="at-history-type-badge ${typeClass}">${typeLabel}</span>`;
-            
+
             return `
                 <div class="at-history-item">
                     <span class="at-history-icon">${icon}</span>
@@ -695,7 +695,7 @@
             `;
         }).join('');
     }
-    
+
     // HTML 转义函数
     function escapeHtml(text) {
         const div = document.createElement('div');
@@ -743,7 +743,7 @@
         };
 
         const nextRuns = calculateNextRuns(config, 5);
-        
+
         if (nextRuns.length === 0) {
             container.innerHTML = `<li>${t('autoTrigger.selectTimeHint')}</li>`;
             return;
@@ -754,17 +754,17 @@
             return `<li>${idx + 1}. ${formatDateTime(date)}</li>`;
         }).join('');
     }
-    
+
     // 解析 Crontab 并计算下次运行时间（简化版）
     function calculateCrontabNextRuns(crontab, count) {
         try {
             const parts = crontab.split(/\s+/);
             if (parts.length < 5) return [];
-            
+
             const [minute, hour, dayOfMonth, month, dayOfWeek] = parts;
             const results = [];
             const now = new Date();
-            
+
             // 简化解析：支持 * 和具体数值
             const parseField = (field, max) => {
                 if (field === '*') return Array.from({ length: max + 1 }, (_, i) => i);
@@ -779,10 +779,10 @@
                 }
                 return [Number(field)];
             };
-            
+
             const minutes = parseField(minute, 59);
             const hours = parseField(hour, 23);
-            
+
             // 遍历未来 7 天
             for (let dayOffset = 0; dayOffset < 7 && results.length < count; dayOffset++) {
                 for (const h of hours) {
@@ -798,7 +798,7 @@
                     if (results.length >= count) break;
                 }
             }
-            
+
             return results;
         } catch {
             return [];
@@ -871,8 +871,8 @@
         } else if (date.toDateString() === tomorrow.toDateString()) {
             return `${t('time.tomorrow')} ${timeStr}`;
         } else {
-            const dayKeys = ['time.sunday', 'time.monday', 'time.tuesday', 'time.wednesday', 
-                           'time.thursday', 'time.friday', 'time.saturday'];
+            const dayKeys = ['time.sunday', 'time.monday', 'time.tuesday', 'time.wednesday',
+                'time.thursday', 'time.friday', 'time.saturday'];
             return `${t(dayKeys[date.getDay()])} ${timeStr}`;
         }
     }
@@ -882,7 +882,7 @@
     function updateState(state) {
         currentState = state;
         availableModels = filterAvailableModels(state.availableModels || []);
-        
+
         if (state.schedule?.selectedModels) {
             selectedModels = state.schedule.selectedModels;
         }
@@ -895,7 +895,7 @@
 
         // 隐藏测试中状态（如果收到新状态说明测试完成了）
         hideTestingStatus();
-        
+
         updateAuthUI(state.authorization);
         updateStatusUI(state);
         updateHistoryCount(state.recentTriggers?.length || 0);
@@ -931,29 +931,69 @@
 
         if (!authRow) return;
 
-        if (auth?.isAuthorized) {
+        const accounts = auth?.accounts || [];
+        const hasAccounts = accounts.length > 0;
+        const activeAccount = auth?.activeAccount;
+
+        if (hasAccounts) {
+            // Multi-account view
+            const accountListHtml = accounts.map(acc => {
+                const isActive = acc.email === activeAccount;
+                return `
+                    <div class="at-account-item ${isActive ? 'active' : ''}" data-email="${acc.email}">
+                        <div class="at-account-info">
+                            <span class="at-account-icon">${isActive ? '✅' : '👤'}</span>
+                            <span class="at-account-email">${acc.email}</span>
+                            ${isActive ? `<span class="at-account-badge">${t('autoTrigger.accountActive')}</span>` : ''}
+                        </div>
+                        <div class="at-account-actions">
+                            ${!isActive ? `<button class="at-btn at-btn-small at-btn-secondary at-switch-account-btn" data-email="${acc.email}">${t('autoTrigger.switchAccount')}</button>` : ''}
+                            <button class="at-btn at-btn-small at-btn-danger at-remove-account-btn" data-email="${acc.email}">${t('autoTrigger.removeAccount')}</button>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
             authRow.innerHTML = `
-                <div class="at-auth-info">
-                    <span class="at-auth-icon">✅</span>
-                    <span class="at-auth-text">${t('autoTrigger.authorized')}</span>
-                    <span class="at-auth-email">${auth.email || ''}</span>
+                <div class="at-auth-header">
+                    <span class="at-auth-title">${t('autoTrigger.accountList')}</span>
+                    <button id="at-add-account-btn" class="at-btn at-btn-primary at-btn-small">➕ ${t('autoTrigger.addAccount')}</button>
                 </div>
-                <div class="at-auth-actions">
-                    <button id="at-reauth-btn" class="at-btn at-btn-secondary">${t('autoTrigger.reauthorizeBtn')}</button>
-                    <button id="at-revoke-btn" class="at-btn at-btn-danger">${t('autoTrigger.revokeBtn')}</button>
+                <div class="at-account-list">
+                    ${accountListHtml}
                 </div>
             `;
+
             statusGrid?.classList.remove('hidden');
             actions?.classList.remove('hidden');
 
-            // 重新绑定按钮事件
-            document.getElementById('at-reauth-btn')?.addEventListener('click', () => {
-                vscode.postMessage({ command: 'autoTrigger.authorize' });
+            // Bind add account button
+            document.getElementById('at-add-account-btn')?.addEventListener('click', () => {
+                vscode.postMessage({ command: 'autoTrigger.addAccount' });
             });
-            document.getElementById('at-revoke-btn')?.addEventListener('click', () => {
-                openRevokeModal();
+
+            // Bind switch account buttons
+            authRow.querySelectorAll('.at-switch-account-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const email = btn.dataset.email;
+                    vscode.postMessage({ command: 'autoTrigger.switchAccount', email });
+                });
             });
+
+            // Bind remove account buttons
+            authRow.querySelectorAll('.at-remove-account-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const email = btn.dataset.email;
+                    if (confirm(t('autoTrigger.confirmRemove'))) {
+                        vscode.postMessage({ command: 'autoTrigger.removeAccount', email });
+                    }
+                });
+            });
+
         } else {
+            // No accounts - show authorize button
             authRow.innerHTML = `
                 <div class="at-auth-info">
                     <span class="at-auth-icon">⚠️</span>
@@ -974,7 +1014,7 @@
 
     function updateStatusUI(state) {
         const schedule = state.schedule || {};
-        
+
         // 状态
         const statusValue = document.getElementById('at-status-value');
         if (statusValue) {
@@ -1011,8 +1051,8 @@
                 modeText = `${t('autoTrigger.daily')} ${times}${suffix}`;
             } else if (schedule.repeatMode === 'weekly' && schedule.weeklyDays?.length) {
                 // 显示选择的天和时间点（换行分开）
-                const dayNames = [t('time.sunday'), t('time.monday'), t('time.tuesday'), 
-                                  t('time.wednesday'), t('time.thursday'), t('time.friday'), t('time.saturday')];
+                const dayNames = [t('time.sunday'), t('time.monday'), t('time.tuesday'),
+                t('time.wednesday'), t('time.thursday'), t('time.friday'), t('time.saturday')];
                 const days = schedule.weeklyDays.map(d => dayNames[d] || d).join(', ');
                 const times = schedule.weeklyTimes?.slice(0, 5).join(', ') || '';
                 const timeSuffix = schedule.weeklyTimes?.length > 5 ? '...' : '';
@@ -1072,7 +1112,7 @@
 
     window.addEventListener('message', event => {
         const message = event.data;
-        
+
         switch (message.type) {
             case 'autoTriggerState':
                 updateState(message.data);

--- a/src/view/webview/dashboard.css
+++ b/src/view/webview/dashboard.css
@@ -13,12 +13,12 @@
     --accent-hover: var(--vscode-button-hoverBackground, #1f6feb);
     --border-color: var(--vscode-widget-border, #30363d);
     --font-family: var(--vscode-font-family, -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, Helvetica, Arial, sans-serif);
-    
+
     /* 语义色 - 使用更鲜艳的终端/图表颜色 */
     --success: var(--vscode-terminal-ansiGreen, var(--vscode-charts-green, #4cca6d));
     --warning: var(--vscode-terminal-ansiYellow, var(--vscode-charts-yellow, #f1e05a));
     --danger: var(--vscode-terminal-ansiRed, var(--vscode-charts-red, #da3633));
-    
+
     /* Tooltip 专用 */
     --tooltip-bg: var(--vscode-editorWidget-background, #1e1e1e);
     --tooltip-fg: var(--vscode-editorWidget-foreground, #cccccc);
@@ -156,6 +156,94 @@ body {
     gap: 8px;
 }
 
+/* Multi-Account Authorization Styles */
+.quota-auth-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    width: 100%;
+    margin-bottom: 12px;
+}
+
+.quota-auth-title {
+    font-weight: 600;
+    font-size: 14px;
+    color: var(--text-primary);
+}
+
+.quota-auth-row {
+    display: flex;
+    flex-direction: column;
+    gap: 12px;
+    width: 100%;
+}
+
+.quota-account-list {
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    width: 100%;
+}
+
+.quota-account-item {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 10px 14px;
+    background: rgba(255, 255, 255, 0.03);
+    border: 1px solid var(--border-color);
+    border-radius: 8px;
+    transition: all 0.2s ease;
+}
+
+.quota-account-item:hover {
+    border-color: var(--accent);
+    background: rgba(255, 255, 255, 0.05);
+}
+
+.quota-account-item.active {
+    border-color: var(--success);
+    background: rgba(76, 175, 80, 0.08);
+}
+
+.quota-account-info {
+    display: flex;
+    align-items: center;
+    gap: 10px;
+    flex: 1;
+    min-width: 0;
+}
+
+.quota-account-icon {
+    font-size: 18px;
+    flex-shrink: 0;
+}
+
+.quota-account-email {
+    font-size: 13px;
+    color: var(--text-primary);
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+.quota-account-badge {
+    font-size: 10px;
+    padding: 2px 8px;
+    background: rgba(76, 175, 80, 0.2);
+    color: var(--success);
+    border-radius: 10px;
+    font-weight: 600;
+    flex-shrink: 0;
+}
+
+.quota-account-actions {
+    display: flex;
+    gap: 6px;
+    flex-shrink: 0;
+    margin-left: 12px;
+}
+
 .model-manager-body {
     display: flex;
     flex-direction: column;
@@ -220,7 +308,9 @@ body {
 }
 
 @keyframes spin {
-    to { transform: rotate(360deg); }
+    to {
+        transform: rotate(360deg);
+    }
 }
 
 /* ============ 离线状态卡片 ============ */
@@ -385,11 +475,11 @@ body {
     border-radius: 50%;
 }
 
-input:checked + .slider {
+input:checked+.slider {
     background-color: var(--accent);
 }
 
-input:checked + .slider:before {
+input:checked+.slider:before {
     transform: translateX(16px);
 }
 
@@ -621,20 +711,44 @@ input:checked + .slider:before {
 /* ============ 动画 ============ */
 
 @keyframes fadeIn {
-    from { opacity: 0; transform: translateY(10px); }
-    to { opacity: 1; transform: translateY(0); }
+    from {
+        opacity: 0;
+        transform: translateY(10px);
+    }
+
+    to {
+        opacity: 1;
+        transform: translateY(0);
+    }
 }
 
 .card {
     animation: fadeIn 0.3s ease-out;
 }
 
-.card:nth-child(1) { animation-delay: 0s; }
-.card:nth-child(2) { animation-delay: 0.05s; }
-.card:nth-child(3) { animation-delay: 0.1s; }
-.card:nth-child(4) { animation-delay: 0.15s; }
-.card:nth-child(5) { animation-delay: 0.2s; }
-.card:nth-child(6) { animation-delay: 0.25s; }
+.card:nth-child(1) {
+    animation-delay: 0s;
+}
+
+.card:nth-child(2) {
+    animation-delay: 0.05s;
+}
+
+.card:nth-child(3) {
+    animation-delay: 0.1s;
+}
+
+.card:nth-child(4) {
+    animation-delay: 0.15s;
+}
+
+.card:nth-child(5) {
+    animation-delay: 0.2s;
+}
+
+.card:nth-child(6) {
+    animation-delay: 0.25s;
+}
 
 /* ============ Toast 通知 ============ */
 
@@ -668,13 +782,14 @@ input:checked + .slider:before {
 }
 
 @keyframes slideUp {
-    from { 
-        opacity: 0; 
-        transform: translateX(-50%) translateY(20px); 
+    from {
+        opacity: 0;
+        transform: translateX(-50%) translateY(20px);
     }
-    to { 
-        opacity: 1; 
-        transform: translateX(-50%) translateY(0); 
+
+    to {
+        opacity: 1;
+        transform: translateX(-50%) translateY(0);
     }
 }
 
@@ -693,7 +808,7 @@ input:checked + .slider:before {
     font-size: 11px;
     font-weight: bold;
     letter-spacing: 0.5px;
-    box-shadow: 0 2px 4px rgba(0,0,0,0.2);
+    box-shadow: 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .profile-grid {
@@ -846,7 +961,9 @@ input:checked + .slider:before {
     background-color: rgba(255, 255, 255, 0.1);
 }
 
-.icon-eye, .icon-eye-closed, .icon-hide {
+.icon-eye,
+.icon-eye-closed,
+.icon-hide {
     font-size: 14px;
 }
 
@@ -1039,10 +1156,23 @@ input:checked + .slider:before {
 }
 
 @keyframes bounceIn {
-    0% { transform: scale(0.3); opacity: 0; }
-    50% { transform: scale(1.05); opacity: 1; }
-    70% { transform: scale(0.9); }
-    100% { transform: scale(1); }
+    0% {
+        transform: scale(0.3);
+        opacity: 0;
+    }
+
+    50% {
+        transform: scale(1.05);
+        opacity: 1;
+    }
+
+    70% {
+        transform: scale(0.9);
+    }
+
+    100% {
+        transform: scale(1);
+    }
 }
 
 /* 模型名称可悬停样式 */
@@ -1115,8 +1245,15 @@ input:checked + .slider:before {
 }
 
 @keyframes tagPulse {
-    0%, 100% { opacity: 1; }
-    50% { opacity: 0.85; }
+
+    0%,
+    100% {
+        opacity: 1;
+    }
+
+    50% {
+        opacity: 0.85;
+    }
 }
 
 /* 标题包装器（用于标题 + New 标签对齐） */
@@ -1153,8 +1290,14 @@ input:checked + .slider:before {
 }
 
 @keyframes twinkle {
-    from { opacity: 0.6; }
-    to { opacity: 1; transform: scale(1.1); }
+    from {
+        opacity: 0.6;
+    }
+
+    to {
+        opacity: 1;
+        transform: scale(1.1);
+    }
 }
 
 /* 能力触发器（标题栏内） */
@@ -1206,13 +1349,15 @@ input:checked + .slider:before {
 /* 推荐项高亮 */
 .rich-tooltip-item.recommended-item {
     background: linear-gradient(90deg, rgba(255, 215, 0, 0.08), transparent);
-    margin: -6px -12px 6px -12px; /* 负边距抵消 padding */
+    margin: -6px -12px 6px -12px;
+    /* 负边距抵消 padding */
     padding: 8px 12px;
     border-bottom: 1px solid rgba(255, 215, 0, 0.2);
 }
 
 .rich-tooltip-item.recommended-item .text {
-    color: #DAA520; /* GoldenRod */
+    color: #DAA520;
+    /* GoldenRod */
     font-weight: 600;
 }
 
@@ -1297,7 +1442,8 @@ input:checked + .slider:before {
     flex: 1;
     margin-right: 20px;
     display: flex;
-    align-items: center; /* 确保文字块内部也垂直居中 */
+    align-items: center;
+    /* 确保文字块内部也垂直居中 */
 }
 
 .auto-group-link {
@@ -1313,13 +1459,16 @@ input:checked + .slider:before {
     font-size: 12px;
     font-weight: 500;
     transition: all 0.2s ease;
-    white-space: nowrap; /* 防止按钮换行 */
-    height: 32px; /* 固定高度确保对齐 */
+    white-space: nowrap;
+    /* 防止按钮换行 */
+    height: 32px;
+    /* 固定高度确保对齐 */
 }
 
 .auto-group-link:hover {
     background: var(--accent);
-    color: white; /* 悬停变为实心 */
+    color: white;
+    /* 悬停变为实心 */
     box-shadow: 0 4px 12px rgba(47, 129, 247, 0.3);
     transform: translateY(-1px);
 }
@@ -1401,6 +1550,7 @@ input:checked + .slider:before {
         opacity: 0;
         transform: translateY(-20px);
     }
+
     to {
         opacity: 1;
         transform: translateY(0);
@@ -1694,6 +1844,7 @@ input:checked + .slider:before {
     background: rgba(162, 119, 255, 0.1);
     transform: translateY(-2px);
 }
+
 /* ============ Status Bar Format Selector ============ */
 
 .modal-content-wide {
@@ -2274,16 +2425,47 @@ input:checked + .slider:before {
 }
 
 @keyframes bellShake {
-    0%, 100% { transform: rotate(0deg); }
-    10% { transform: rotate(15deg); }
-    20% { transform: rotate(-15deg); }
-    30% { transform: rotate(12deg); }
-    40% { transform: rotate(-12deg); }
-    50% { transform: rotate(8deg); }
-    60% { transform: rotate(-8deg); }
-    70% { transform: rotate(4deg); }
-    80% { transform: rotate(-4deg); }
-    90% { transform: rotate(2deg); }
+
+    0%,
+    100% {
+        transform: rotate(0deg);
+    }
+
+    10% {
+        transform: rotate(15deg);
+    }
+
+    20% {
+        transform: rotate(-15deg);
+    }
+
+    30% {
+        transform: rotate(12deg);
+    }
+
+    40% {
+        transform: rotate(-12deg);
+    }
+
+    50% {
+        transform: rotate(8deg);
+    }
+
+    60% {
+        transform: rotate(-8deg);
+    }
+
+    70% {
+        transform: rotate(4deg);
+    }
+
+    80% {
+        transform: rotate(-4deg);
+    }
+
+    90% {
+        transform: rotate(2deg);
+    }
 }
 
 /* ============ Announcement List Modal ============ */

--- a/src/view/webview/dashboard.js
+++ b/src/view/webview/dashboard.js
@@ -3,7 +3,7 @@
  * 处理 Webview 交互逻辑
  */
 
-(function() {
+(function () {
     'use strict';
 
     // 获取 VS Code API（保存到全局供其他模块复用）
@@ -108,12 +108,12 @@
         if (state.quotaSource) {
             currentQuotaSource = state.quotaSource;
         }
-        
+
         // isProfileHidden and isDataMasked are now loaded from config in handleMessage
 
         // 绑定事件
         refreshBtn.addEventListener('click', handleRefresh);
-        
+
         // 初始化富文本 Tooltip
         initRichTooltip();
         if (resetOrderBtn) {
@@ -130,13 +130,13 @@
         if (toggleProfileBtn) {
             toggleProfileBtn.addEventListener('click', handleToggleProfile);
         }
-        
+
         // 分组开关按钮
         const toggleGroupingBtn = document.getElementById('toggle-grouping-btn');
         if (toggleGroupingBtn) {
             toggleGroupingBtn.addEventListener('click', handleToggleGrouping);
         }
-        
+
         // 设置按钮
         const settingsBtn = document.getElementById('settings-btn');
         if (settingsBtn) {
@@ -151,25 +151,25 @@
                 requestQuotaSourceChange(source);
             });
         });
-        
+
         // 关闭设置模态框
         const closeSettingsBtn = document.getElementById('close-settings-btn');
         if (closeSettingsBtn) {
             closeSettingsBtn.addEventListener('click', closeSettingsModal);
         }
-        
+
         // 重命名模态框 - 关闭按钮
         const closeRenameBtn = document.getElementById('close-rename-btn');
         if (closeRenameBtn) {
             closeRenameBtn.addEventListener('click', closeRenameModal);
         }
-        
+
         // 重命名模态框 - 确定按钮
         const saveRenameBtn = document.getElementById('save-rename-btn');
         if (saveRenameBtn) {
             saveRenameBtn.addEventListener('click', saveRename);
         }
-        
+
         // 重命名输入框 - 回车键确认
         const renameInput = document.getElementById('rename-input');
         if (renameInput) {
@@ -192,7 +192,7 @@
         document.getElementById('model-manager-select-recommended')?.addEventListener('click', () => {
             updateModelManagerSelection('recommended');
         });
-        
+
         // 重置名称按钮
         const resetNameBtn = document.getElementById('reset-name-btn');
         if (resetNameBtn) {
@@ -226,19 +226,19 @@
         // Announcement Events
         const announcementBtn = document.getElementById('announcement-btn');
         if (announcementBtn) announcementBtn.addEventListener('click', openAnnouncementList);
-        
+
         const announcementListClose = document.getElementById('announcement-list-close');
         if (announcementListClose) announcementListClose.addEventListener('click', closeAnnouncementList);
-        
+
         const announcementMarkAllRead = document.getElementById('announcement-mark-all-read');
         if (announcementMarkAllRead) announcementMarkAllRead.addEventListener('click', markAllAnnouncementsRead);
-        
+
         const announcementPopupLater = document.getElementById('announcement-popup-later');
         if (announcementPopupLater) announcementPopupLater.addEventListener('click', closeAnnouncementPopup);
-        
+
         const announcementPopupGotIt = document.getElementById('announcement-popup-got-it');
         if (announcementPopupGotIt) announcementPopupGotIt.addEventListener('click', handleAnnouncementGotIt);
-        
+
         const announcementPopupAction = document.getElementById('announcement-popup-action');
         if (announcementPopupAction) announcementPopupAction.addEventListener('click', handleAnnouncementAction);
 
@@ -263,21 +263,21 @@
         // 通知扩展已准备就绪
         vscode.postMessage({ command: 'init' });
     }
-    
+
     // ============ Tab 导航 ============
-    
+
     function initTabNavigation() {
         const tabButtons = document.querySelectorAll('.tab-btn');
         const tabContents = document.querySelectorAll('.tab-content');
-        
+
         tabButtons.forEach(btn => {
             btn.addEventListener('click', () => {
                 const targetTab = btn.getAttribute('data-tab');
-                
+
                 // 更新按钮状态
                 tabButtons.forEach(b => b.classList.remove('active'));
                 btn.classList.add('active');
-                
+
                 // 更新内容显示
                 tabContents.forEach(content => {
                     if (content.id === `tab-${targetTab}`) {
@@ -286,15 +286,15 @@
                         content.classList.remove('active');
                     }
                 });
-                
+
                 // 通知扩展 Tab 切换（可用于状态同步）
                 vscode.postMessage({ command: 'tabChanged', tab: targetTab });
             });
         });
     }
-    
+
     // ============ 设置模态框 ============
-    
+
     function openSettingsModal() {
         if (settingsModal) {
             // 从当前配置填充值
@@ -310,7 +310,7 @@
             if (displayModeSelect) {
                 const currentDisplayMode = currentConfig.displayMode || 'webview';
                 displayModeSelect.value = currentDisplayMode;
-                
+
                 displayModeSelect.onchange = () => {
                     const newMode = displayModeSelect.value;
                     if (newMode === 'quickpick') {
@@ -325,29 +325,29 @@
 
             // 初始化状态栏格式选择器
             initStatusBarFormatSelector();
-            
+
             // 初始化即时保存事件
             initSettingsAutoSave();
 
             settingsModal.classList.remove('hidden');
         }
     }
-    
+
     /**
      * 初始化状态栏格式选择器（下拉框）
      */
     function initStatusBarFormatSelector() {
         const formatSelect = document.getElementById('statusbar-format');
         if (!formatSelect) return;
-        
+
         const currentFormat = currentConfig.statusBarFormat || 'standard';
         formatSelect.value = currentFormat;
-        
+
         // 绑定 change 事件
         formatSelect.onchange = null;
         formatSelect.addEventListener('change', () => {
             const format = formatSelect.value;
-            
+
             // 发送消息到扩展，立即更新状态栏
             vscode.postMessage({
                 command: 'updateStatusBarFormat',
@@ -362,27 +362,27 @@
     function initLanguageSelector() {
         const languageSelect = document.getElementById('language-select');
         if (!languageSelect) return;
-        
+
         // 设置当前语言
         const currentLanguage = currentConfig.language || 'auto';
         languageSelect.value = currentLanguage;
-        
+
         // 绑定 change 事件
         languageSelect.onchange = null;
         languageSelect.addEventListener('change', () => {
             const newLanguage = languageSelect.value;
-            
+
             // 发送消息到扩展
             vscode.postMessage({
                 command: 'updateLanguage',
                 language: newLanguage
             });
-            
+
             // 显示提示需要重新打开面板
             showToast(i18n['language.changed'] || 'Language changed. Reopen panel to apply.', 'info');
         });
     }
-    
+
     /**
      * 初始化设置自动保存（即时生效）
      */
@@ -390,7 +390,7 @@
         const notificationCheckbox = document.getElementById('notification-enabled');
         const warningInput = document.getElementById('warning-threshold');
         const criticalInput = document.getElementById('critical-threshold');
-        
+
         // 通知开关即时保存
         if (notificationCheckbox) {
             notificationCheckbox.onchange = null;
@@ -401,7 +401,7 @@
                 });
             });
         }
-        
+
         // 阈值输入框失焦时自动钳位并保存
         if (warningInput) {
             warningInput.onblur = null;
@@ -409,7 +409,7 @@
                 clampAndSaveThresholds();
             });
         }
-        
+
         if (criticalInput) {
             criticalInput.onblur = null;
             criticalInput.addEventListener('blur', () => {
@@ -417,14 +417,14 @@
             });
         }
     }
-    
+
     /**
      * 钳位阈值并保存
      */
     function clampAndSaveThresholds() {
         const warningInput = document.getElementById('warning-threshold');
         const criticalInput = document.getElementById('critical-threshold');
-        
+
         let warningValue = parseInt(warningInput?.value, 10) || 30;
         let criticalValue = parseInt(criticalInput?.value, 10) || 10;
 
@@ -446,7 +446,7 @@
 
         saveThresholds();
     }
-    
+
     /**
      * 保存阈值设置
      */
@@ -467,33 +467,33 @@
             criticalThreshold: criticalValue
         });
     }
-    
+
     function closeSettingsModal() {
         if (settingsModal) {
             settingsModal.classList.add('hidden');
         }
     }
-    
+
     // ============ 重命名模态框 ============
-    
+
     function openRenameModal(groupId, currentName, modelIds) {
         if (renameModal) {
             renameGroupId = groupId;
             renameModelIds = modelIds || [];
             isRenamingModel = false; // 分组重命名模式
             renameModelId = null;
-            
+
             const renameInput = document.getElementById('rename-input');
             if (renameInput) {
                 renameInput.value = currentName || '';
                 renameInput.focus();
                 renameInput.select();
             }
-            
+
             renameModal.classList.remove('hidden');
         }
     }
-    
+
     /**
      * 打开模型重命名模态框（非分组模式）
      * @param {string} modelId 模型 ID
@@ -506,18 +506,18 @@
             renameGroupId = null;
             renameModelIds = [];
             renameOriginalName = originalName || currentName || ''; // 保存原始名称
-            
+
             const renameInput = document.getElementById('rename-input');
             if (renameInput) {
                 renameInput.value = currentName || '';
                 renameInput.focus();
                 renameInput.select();
             }
-            
+
             renameModal.classList.remove('hidden');
         }
     }
-    
+
     function closeRenameModal() {
         if (renameModal) {
             renameModal.classList.add('hidden');
@@ -528,16 +528,16 @@
             renameOriginalName = '';
         }
     }
-    
+
     function saveRename() {
         const renameInput = document.getElementById('rename-input');
         const newName = renameInput?.value?.trim();
-        
+
         if (!newName) {
             showToast(i18n['model.nameEmpty'] || i18n['grouping.nameEmpty'] || 'Name cannot be empty', 'error');
             return;
         }
-        
+
         if (isRenamingModel && renameModelId) {
             // 模型重命名模式
             vscode.postMessage({
@@ -545,7 +545,7 @@
                 modelId: renameModelId,
                 groupName: newName  // 复用 groupName 字段
             });
-            
+
             showToast((i18n['model.renamed'] || 'Model renamed to {name}').replace('{name}', newName), 'success');
         } else if (renameGroupId && renameModelIds.length > 0) {
             // 分组重命名模式
@@ -555,10 +555,10 @@
                 groupName: newName,
                 modelIds: renameModelIds
             });
-            
+
             showToast((i18n['grouping.renamed'] || 'Renamed to {name}').replace('{name}', newName), 'success');
         }
-        
+
         closeRenameModal();
     }
     /**
@@ -567,7 +567,7 @@
     function resetName() {
         const renameInput = document.getElementById('rename-input');
         if (!renameInput) return;
-        
+
         if (isRenamingModel && renameModelId && renameOriginalName) {
             // 模型重置模式：将原始名称填入输入框
             renameInput.value = renameOriginalName;
@@ -575,12 +575,12 @@
         }
         // 分组重置暂不支持
     }
-    
+
     function handleToggleProfile() {
         // Send command to extension to toggle and persist in VS Code config
         vscode.postMessage({ command: 'toggleProfile' });
     }
-    
+
     function updateToggleProfileButton() {
         const btn = document.getElementById('toggle-profile-btn');
         if (btn) {
@@ -593,12 +593,12 @@
             }
         }
     }
-    
+
     function handleToggleGrouping() {
         // 发送切换分组的消息给扩展
         vscode.postMessage({ command: 'toggleGrouping' });
     }
-    
+
     function updateToggleGroupingButton(enabled) {
         const btn = document.getElementById('toggle-grouping-btn');
         if (btn) {
@@ -644,21 +644,21 @@
 
     function handleMessage(event) {
         const message = event.data;
-        
+
         // 处理标签页切换消息
         if (message.type === 'switchTab' && message.tab) {
             switchToTab(message.tab);
             return;
         }
-        
+
         if (message.type === 'telemetry_update') {
             isRefreshing = false;
             updateRefreshButton();
-            
+
             // 保存配置
             if (message.config) {
                 currentConfig = message.config;
-                
+
                 // 从配置读取 profileHidden（持久化存储）
                 if (message.config.profileHidden !== undefined) {
                     isProfileHidden = message.config.profileHidden;
@@ -705,7 +705,7 @@
                 updateQuotaAuthUI();
             }
         }
-        
+
         // 处理公告状态更新
         if (message.type === 'announcementState') {
             handleAnnouncementState(message.data);
@@ -791,25 +791,65 @@
 
         card.classList.remove('hidden');
         const auth = authorizationStatus;
-        if (auth?.isAuthorized) {
+        const accounts = auth?.accounts || [];
+        const hasAccounts = accounts.length > 0;
+        const activeAccount = auth?.activeAccount;
+
+        if (hasAccounts) {
+            // Multi-account view
+            const accountListHtml = accounts.map(acc => {
+                const isActive = acc.email === activeAccount;
+                return `
+                    <div class="quota-account-item ${isActive ? 'active' : ''}" data-email="${acc.email}">
+                        <div class="quota-account-info">
+                            <span class="quota-account-icon">${isActive ? '✅' : '👤'}</span>
+                            <span class="quota-account-email">${acc.email}</span>
+                            ${isActive ? `<span class="quota-account-badge">${i18n['autoTrigger.accountActive'] || 'Active'}</span>` : ''}
+                        </div>
+                        <div class="quota-account-actions">
+                            ${!isActive ? `<button class="at-btn at-btn-small at-btn-secondary quota-switch-account-btn" data-email="${acc.email}">${i18n['autoTrigger.switchAccount'] || 'Switch'}</button>` : ''}
+                            <button class="at-btn at-btn-small at-btn-danger quota-remove-account-btn" data-email="${acc.email}">${i18n['autoTrigger.removeAccount'] || 'Remove'}</button>
+                        </div>
+                    </div>
+                `;
+            }).join('');
+
             row.innerHTML = `
-                <div class="quota-auth-info">
-                    <span class="quota-auth-icon">✅</span>
-                    <span class="quota-auth-text">${i18n['autoTrigger.authorized'] || 'Authorized'}</span>
-                    <span class="quota-auth-email">${auth.email || ''}</span>
+                <div class="quota-auth-header">
+                    <span class="quota-auth-title">${i18n['autoTrigger.accountList'] || 'Authorized Accounts'}</span>
+                    <button id="quota-add-account-btn" class="at-btn at-btn-primary at-btn-small">➕ ${i18n['autoTrigger.addAccount'] || 'Add Account'}</button>
                 </div>
-                <div class="quota-auth-actions">
-                    <button id="quota-reauth-btn" class="at-btn at-btn-secondary">${i18n['autoTrigger.reauthorizeBtn'] || 'Reauthorize'}</button>
-                    <button id="quota-revoke-btn" class="at-btn at-btn-danger">${i18n['autoTrigger.revokeBtn'] || 'Revoke'}</button>
+                <div class="quota-account-list">
+                    ${accountListHtml}
                 </div>
             `;
-            document.getElementById('quota-reauth-btn')?.addEventListener('click', () => {
-                vscode.postMessage({ command: 'autoTrigger.authorize' });
+
+            // Bind add account button
+            document.getElementById('quota-add-account-btn')?.addEventListener('click', () => {
+                vscode.postMessage({ command: 'autoTrigger.addAccount' });
             });
-            document.getElementById('quota-revoke-btn')?.addEventListener('click', () => {
-                document.getElementById('at-revoke-modal')?.classList.remove('hidden');
+
+            // Bind switch account buttons
+            row.querySelectorAll('.quota-switch-account-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const email = btn.dataset.email;
+                    vscode.postMessage({ command: 'autoTrigger.switchAccount', email });
+                });
+            });
+
+            // Bind remove account buttons
+            row.querySelectorAll('.quota-remove-account-btn').forEach(btn => {
+                btn.addEventListener('click', (e) => {
+                    e.stopPropagation();
+                    const email = btn.dataset.email;
+                    if (confirm(i18n['autoTrigger.confirmRemove'] || 'Are you sure you want to remove this account?')) {
+                        vscode.postMessage({ command: 'autoTrigger.removeAccount', email });
+                    }
+                });
             });
         } else {
+            // No accounts - show authorize button
             row.innerHTML = `
                 <div class="quota-auth-info">
                     <span class="quota-auth-icon">⚠️</span>
@@ -1056,7 +1096,7 @@
         showToast(i18n['models.saved'] || 'Model visibility updated.', 'success');
         closeModelManagerModal();
     }
-    
+
     /**
      * 切换到指定标签页
      * @param {string} tabId 标签页 ID (如 'auto-trigger')
@@ -1064,15 +1104,15 @@
     function switchToTab(tabId) {
         const tabButtons = document.querySelectorAll('.tab-btn');
         const tabContents = document.querySelectorAll('.tab-content');
-        
+
         // 查找目标按钮
         const targetBtn = document.querySelector(`.tab-btn[data-tab="${tabId}"]`);
         if (!targetBtn) return;
-        
+
         // 更新按钮状态
         tabButtons.forEach(b => b.classList.remove('active'));
         targetBtn.classList.add('active');
-        
+
         // 更新内容显示
         tabContents.forEach(content => {
             if (content.id === `tab-${tabId}`) {
@@ -1115,7 +1155,7 @@
 
         toast.textContent = message;
         toast.className = `toast ${type}`;
-        
+
         // 3秒后隐藏
         setTimeout(() => {
             toast.classList.add('hidden');
@@ -1128,7 +1168,7 @@
         // 使用配置的阈值
         const warningThreshold = currentConfig.warningThreshold || 30;
         const criticalThreshold = currentConfig.criticalThreshold || 10;
-        
+
         if (percentage > warningThreshold) return 'var(--success)';  // 绿色
         if (percentage > criticalThreshold) return 'var(--warning)';  // 黄色
         return 'var(--danger)';                                       // 红色
@@ -1138,7 +1178,7 @@
         // 使用配置的阈值
         const warningThreshold = currentConfig.warningThreshold || 30;
         const criticalThreshold = currentConfig.criticalThreshold || 10;
-        
+
         if (percentage > warningThreshold) return i18n['dashboard.active'] || 'Healthy';   // 健康
         if (percentage > criticalThreshold) return i18n['dashboard.warning'] || 'Warning';  // 警告
         return i18n['dashboard.danger'] || 'Danger';                                        // 危险
@@ -1202,7 +1242,7 @@
             const selector = dragSrcEl.classList.contains('card') ? '.card' : 'tr';
             const dashboardOrTbody = dragSrcEl.parentElement;
             const items = Array.from(dashboardOrTbody.querySelectorAll(selector));
-            
+
             const srcIndex = items.indexOf(dragSrcEl);
             const targetIndex = items.indexOf(this);
 
@@ -1214,21 +1254,21 @@
 
             // Get updated list of all items in this container
             const updatedItems = Array.from(dashboardOrTbody.querySelectorAll(selector));
-            
+
             // 检查是否是分组
             const isGroup = dragSrcEl.classList.contains('group-card') || dragSrcEl.classList.contains('list-group-row');
-            
+
             if (isGroup) {
                 const groupOrder = updatedItems
                     .map(item => item.getAttribute('data-group-id'))
                     .filter(id => id !== null);
-                
+
                 vscode.postMessage({ command: 'updateGroupOrder', order: groupOrder });
             } else {
                 const modelOrder = updatedItems
                     .map(item => item.getAttribute('data-id'))
                     .filter(id => id !== null);
-                
+
                 vscode.postMessage({ command: 'updateOrder', order: modelOrder });
             }
         }
@@ -1270,18 +1310,18 @@
 
         // 更新分组按钮状态
         updateToggleGroupingButton(config?.groupingEnabled);
-        
+
         // 如果启用了分组显示，渲染分组卡片
         if (config?.groupingEnabled && snapshot.groups && snapshot.groups.length > 0) {
             // 渲染自动分组按钮区域
             renderAutoGroupBar();
-            
+
             // 分组排序：支持自定义顺序
             let groups = [...snapshot.groups];
             if (config?.groupOrder?.length > 0) {
                 const orderMap = new Map();
                 config.groupOrder.forEach((id, index) => orderMap.set(id, index));
-                
+
                 groups.sort((a, b) => {
                     const idxA = orderMap.has(a.groupId) ? orderMap.get(a.groupId) : 99999;
                     const idxB = orderMap.has(b.groupId) ? orderMap.get(b.groupId) : 99999;
@@ -1290,7 +1330,7 @@
                     return a.remainingPercentage - b.remainingPercentage;
                 });
             }
-            
+
             groups.forEach(group => {
                 renderGroupCard(group, config?.pinnedGroups || []);
             });
@@ -1395,7 +1435,7 @@
             </button>
         `;
         dashboard.appendChild(bar);
-        
+
         // 绑定点击事件 - 打开自定义分组弹框
         const btn = bar.querySelector('#manage-group-btn');
         if (btn) {
@@ -1407,16 +1447,16 @@
 
     function openCustomGroupingModal() {
         if (!customGroupingModal || !lastSnapshot) return;
-        
+
         // 初始化状态
         const models = lastSnapshot.models || [];
         customGroupingState.allModels = models;
         customGroupingState.groupMappings = { ...(currentConfig.groupMappings || {}) };
-        
+
         // 从现有映射构建分组
         const groupMap = new Map(); // groupId -> { id, name, modelIds }
         const groupNames = currentConfig.groupCustomNames || {};
-        
+
         for (const model of models) {
             const groupId = customGroupingState.groupMappings[model.modelId];
             if (groupId) {
@@ -1438,12 +1478,12 @@
                 groupMap.get(groupId).modelIds.push(model.modelId);
             }
         }
-        
+
         customGroupingState.groups = Array.from(groupMap.values());
-        
+
         // 渲染弹框内容
         renderCustomGroupingContent();
-        
+
         customGroupingModal.classList.remove('hidden');
     }
 
@@ -1456,13 +1496,13 @@
     function renderCustomGroupingContent() {
         const groupsList = document.getElementById('custom-groups-list');
         const ungroupedList = document.getElementById('ungrouped-models-list');
-        
+
         if (!groupsList || !ungroupedList) return;
-        
+
         // 获取已分组的模型 ID
         const groupedModelIds = new Set();
         customGroupingState.groups.forEach(g => g.modelIds.forEach(id => groupedModelIds.add(id)));
-        
+
         // 渲染分组列表
         if (customGroupingState.groups.length === 0) {
             groupsList.innerHTML = `<div class="empty-groups-hint">${i18n['customGrouping.noModels'] || 'No groups yet. Click "Add Group" to create one.'}</div>`;
@@ -1478,7 +1518,7 @@
                         </span>
                     `;
                 }).join('');
-                
+
                 return `
                     <div class="custom-group-item" data-group-index="${index}">
                         <div class="custom-group-header">
@@ -1499,7 +1539,7 @@
                     </div>
                 `;
             }).join('');
-            
+
             // 绑定事件
             groupsList.querySelectorAll('.remove-model-btn').forEach(btn => {
                 btn.addEventListener('click', handleRemoveModel);
@@ -1514,10 +1554,10 @@
                 input.addEventListener('change', handleGroupNameChange);
             });
         }
-        
+
         // 渲染未分组模型
         const ungroupedModels = customGroupingState.allModels.filter(m => !groupedModelIds.has(m.modelId));
-        
+
         if (ungroupedModels.length === 0) {
             ungroupedList.innerHTML = `<div style="color: var(--text-secondary); font-size: 12px;">${i18n['customGrouping.noModels'] || 'All models are grouped'}</div>`;
         } else {
@@ -1556,7 +1596,7 @@
         e.stopPropagation();
         const groupIndex = parseInt(e.target.dataset.groupIndex, 10);
         const modelId = e.target.dataset.modelId;
-        
+
         if (!isNaN(groupIndex) && modelId) {
             const group = customGroupingState.groups[groupIndex];
             if (group) {
@@ -1576,22 +1616,22 @@
     function handleAddModelToGroup(e) {
         const groupIndex = parseInt(e.target.dataset.groupIndex, 10);
         if (isNaN(groupIndex)) return;
-        
+
         const group = customGroupingState.groups[groupIndex];
         if (!group) return;
-        
+
         // 获取已分组的模型
         const groupedModelIds = new Set();
         customGroupingState.groups.forEach(g => g.modelIds.forEach(id => groupedModelIds.add(id)));
-        
+
         // 获取可用模型（未分组的）
         const availableModels = customGroupingState.allModels.filter(m => !groupedModelIds.has(m.modelId));
-        
+
         if (availableModels.length === 0) {
             showToast(i18n['customGrouping.noModels'] || 'No available models', 'info');
             return;
         }
-        
+
         // 获取组的配额签名（如果组已有模型）
         let groupSignature = null;
         if (group.modelIds.length > 0) {
@@ -1604,7 +1644,7 @@
                 };
             }
         }
-        
+
         // 创建下拉选择菜单
         showModelSelectDropdown(e.target, availableModels, groupSignature, (selectedModelId) => {
             group.modelIds.push(selectedModelId);
@@ -1618,21 +1658,21 @@
         if (existingDropdown) {
             existingDropdown.remove();
         }
-        
+
         const dropdown = document.createElement('div');
         dropdown.className = 'model-select-dropdown';
-        
+
         // 计算位置
         const rect = anchor.getBoundingClientRect();
         dropdown.style.position = 'fixed';
         dropdown.style.left = rect.left + 'px';
         dropdown.style.top = (rect.bottom + 4) + 'px';
-        
+
         // 计算每个模型的兼容性
         const modelsWithCompatibility = models.map(model => {
             let isCompatible = true;
             let incompatibleReason = '';
-            
+
             if (groupSignature) {
                 if (model.remainingPercentage !== groupSignature.remainingPercentage) {
                     isCompatible = false;
@@ -1642,27 +1682,27 @@
                     incompatibleReason = i18n['customGrouping.resetMismatch'] || 'Reset time mismatch';
                 }
             }
-            
+
             return { model, isCompatible, incompatibleReason };
         });
-        
+
         // 排序：兼容的排在前面
         modelsWithCompatibility.sort((a, b) => {
             if (a.isCompatible && !b.isCompatible) return -1;
             if (!a.isCompatible && b.isCompatible) return 1;
             return 0;
         });
-        
+
         // 检查是否有兼容的模型
         const hasCompatibleModels = modelsWithCompatibility.some(m => m.isCompatible);
-        
+
         dropdown.innerHTML = `
             <div class="model-select-list">
                 ${modelsWithCompatibility.map(({ model, isCompatible, incompatibleReason }) => {
-                    const name = currentConfig.modelCustomNames?.[model.modelId] || model.label;
-                    const quotaPct = (model.remainingPercentage || 0).toFixed(1);
-                    
-                    return `
+            const name = currentConfig.modelCustomNames?.[model.modelId] || model.label;
+            const quotaPct = (model.remainingPercentage || 0).toFixed(1);
+
+            return `
                         <label class="model-select-item ${isCompatible ? '' : 'disabled'}" 
                              data-model-id="${model.modelId}" 
                              data-compatible="${isCompatible}">
@@ -1674,7 +1714,7 @@
                             ${!isCompatible ? `<span class="incompatible-reason">${incompatibleReason}</span>` : ''}
                         </label>
                     `;
-                }).join('')}
+        }).join('')}
             </div>
             ${hasCompatibleModels ? `
                 <div class="model-select-footer">
@@ -1684,25 +1724,25 @@
                 </div>
             ` : ''}
         `;
-        
+
         document.body.appendChild(dropdown);
-        
+
         // 选中计数和确认按钮逻辑
         const confirmBtn = dropdown.querySelector('.btn-confirm-add');
         const countSpan = dropdown.querySelector('.selected-count');
         const allCheckboxes = dropdown.querySelectorAll('.model-checkbox');
-        
+
         const updateSelectionState = () => {
             const checkedBoxes = dropdown.querySelectorAll('.model-checkbox:checked');
             const selectedCount = checkedBoxes.length;
-            
+
             // 更新计数和按钮状态
             if (countSpan) countSpan.textContent = selectedCount;
             if (confirmBtn) confirmBtn.disabled = selectedCount === 0;
-            
+
             // 获取当前选中模型的签名（用于动态兼容性检查）
             let currentSignature = groupSignature; // 使用分组已有的签名
-            
+
             if (!currentSignature && selectedCount > 0) {
                 // 如果分组为空，使用第一个选中模型的签名
                 const firstCheckedId = checkedBoxes[0].value;
@@ -1714,22 +1754,22 @@
                     };
                 }
             }
-            
+
             // 更新所有 checkbox 的禁用状态
             allCheckboxes.forEach(cb => {
                 if (cb.checked) return; // 已勾选的不处理
-                
+
                 const modelId = cb.value;
                 const modelData = modelsWithCompatibility.find(m => m.model.modelId === modelId);
                 if (!modelData) return;
-                
+
                 const item = cb.closest('.model-select-item');
                 if (!item) return;
-                
+
                 // 检查兼容性
                 let isCompatible = true;
                 let reason = '';
-                
+
                 if (currentSignature) {
                     if (modelData.model.remainingPercentage !== currentSignature.remainingPercentage) {
                         isCompatible = false;
@@ -1739,10 +1779,10 @@
                         reason = i18n['customGrouping.resetMismatch'] || 'Reset time mismatch';
                     }
                 }
-                
+
                 cb.disabled = !isCompatible;
                 item.classList.toggle('disabled', !isCompatible);
-                
+
                 // 更新或移除不兼容原因显示
                 let reasonSpan = item.querySelector('.incompatible-reason');
                 if (!isCompatible) {
@@ -1757,13 +1797,13 @@
                 }
             });
         };
-        
+
         allCheckboxes.forEach(cb => {
             if (!cb.disabled) {
                 cb.addEventListener('change', updateSelectionState);
             }
         });
-        
+
         // 确认按钮点击
         if (confirmBtn) {
             confirmBtn.addEventListener('click', (e) => {
@@ -1777,7 +1817,7 @@
                 }
             });
         }
-        
+
         // 点击外部关闭
         const closeHandler = (e) => {
             if (!dropdown.contains(e.target) && e.target !== anchor) {
@@ -1797,7 +1837,7 @@
             showToast(i18n['customGrouping.noModels'] || 'No models available', 'info');
             return;
         }
-        
+
         // 保存现有分组名称映射（modelId -> groupName）
         const existingGroupNames = {};
         for (const group of customGroupingState.groups) {
@@ -1805,7 +1845,7 @@
                 existingGroupNames[modelId] = group.name;
             }
         }
-        
+
         // 按配额签名分组
         const signatureMap = new Map(); // signature -> modelIds
         for (const model of models) {
@@ -1815,14 +1855,14 @@
             }
             signatureMap.get(signature).push(model.modelId);
         }
-        
+
         // 转换为分组结构
         customGroupingState.groups = [];
         let groupIndex = 1;
         for (const [signature, modelIds] of signatureMap) {
             // 使用排序后的副本生成稳定的 groupId，保持 modelIds 原始顺序
             const groupId = [...modelIds].sort().join('_');
-            
+
             // 尝试继承现有分组名称
             // 优先使用组内模型之前的分组名称（按出现次数投票）
             const nameVotes = {};
@@ -1832,7 +1872,7 @@
                     nameVotes[existingName] = (nameVotes[existingName] || 0) + 1;
                 }
             }
-            
+
             // 找出投票最多的名称
             let inheritedName = '';
             let maxVotes = 0;
@@ -1842,7 +1882,7 @@
                     inheritedName = name;
                 }
             }
-            
+
             // 如果没有继承名称，使用备选方案
             let groupName = inheritedName;
             if (!groupName) {
@@ -1855,15 +1895,15 @@
                     }
                 }
             }
-            
+
             // 最终备选：单模型用模型名，多模型用 Group N
             if (!groupName) {
                 const firstModel = models.find(m => m.modelId === modelIds[0]);
-                groupName = modelIds.length === 1 
+                groupName = modelIds.length === 1
                     ? (currentConfig.modelCustomNames?.[modelIds[0]] || firstModel?.label || `Group ${groupIndex}`)
                     : `Group ${groupIndex}`;
             }
-            
+
             customGroupingState.groups.push({
                 id: groupId,
                 name: groupName,
@@ -1871,7 +1911,7 @@
             });
             groupIndex++;
         }
-        
+
         renderCustomGroupingContent();
         showToast(i18n['customGrouping.smartGroup'] + ': ' + customGroupingState.groups.length + ' groups', 'success');
     }
@@ -1883,11 +1923,11 @@
             // 移除空分组
             customGroupingState.groups = customGroupingState.groups.filter(g => g.modelIds.length > 0);
         }
-        
+
         // 构建新的 groupMappings
         const newMappings = {};
         const newGroupNames = {};
-        
+
         for (const group of customGroupingState.groups) {
             // 生成稳定的 groupId
             const stableGroupId = group.modelIds.sort().join('_');
@@ -1897,14 +1937,14 @@
                 newGroupNames[modelId] = group.name;
             }
         }
-        
+
         // 发送到扩展保存
         vscode.postMessage({
             command: 'saveCustomGrouping',
             customGroupMappings: newMappings,
             customGroupNames: newGroupNames
         });
-        
+
         showToast(i18n['customGrouping.saved'] || 'Groups saved', 'success');
         closeCustomGroupingModal();
     }
@@ -1924,11 +1964,11 @@
         // Helper for features (with masking support)
         const getFeatureStatus = (enabled) => {
             if (isDataMasked) return `<span class="tag masked">***</span>`;
-            return enabled 
+            return enabled
                 ? `<span class="tag success">${i18n['feature.enabled'] || 'Enabled'}</span>`
                 : `<span class="tag disabled">${i18n['feature.disabled'] || 'Disabled'}</span>`;
         };
-        
+
         // Helper for masking values
         const maskValue = (value) => isDataMasked ? '***' : value;
 
@@ -1946,7 +1986,7 @@
         const detailsClass = isProfileExpanded ? 'profile-details' : 'profile-details hidden';
         const toggleText = isProfileExpanded ? (i18n['profile.less'] || 'Show Less') : (i18n['profile.more'] || 'Show More Details');
         const iconTransform = isProfileExpanded ? 'rotate(180deg)' : 'rotate(0deg)';
-        
+
         // Mask button text
         const maskBtnText = isDataMasked ? (i18n['profile.showData'] || 'Show') : (i18n['profile.hideData'] || 'Hide');
 
@@ -2003,13 +2043,13 @@
             </div>
         `;
         dashboard.appendChild(card);
-        
+
         // Bind event listeners after element creation
         const toggleBtn = card.querySelector('#profile-toggle-btn');
         if (toggleBtn) {
             toggleBtn.addEventListener('click', toggleProfileDetails);
         }
-        
+
         const maskBtn = card.querySelector('#profile-mask-btn');
         if (maskBtn) {
             maskBtn.addEventListener('click', () => {
@@ -2025,7 +2065,7 @@
         const details = document.getElementById('profile-more');
         const text = document.getElementById('profile-toggle-text');
         const icon = document.getElementById('profile-toggle-icon');
-        
+
         if (details.classList.contains('hidden')) {
             details.classList.remove('hidden');
             text.textContent = i18n['profile.less'] || 'Show Less';
@@ -2062,20 +2102,20 @@
             if (target && target !== activeTarget) {
                 activeTarget = target;
                 const html = target.getAttribute('data-tooltip-html');
-                
+
                 // 解码 HTML
                 const decodedHtml = decodeURIComponent(html);
-                
+
                 tooltip.innerHTML = decodedHtml;
                 tooltip.classList.remove('hidden');
-                
+
                 const rect = target.getBoundingClientRect();
                 const tooltipRect = tooltip.getBoundingClientRect();
-                
+
                 // 计算位置：默认在下方，如果下方空间不足则在上方
                 let top = rect.bottom + 8;
                 let left = rect.left + (rect.width - tooltipRect.width) / 2;
-                
+
                 // 边界检查
                 if (top + tooltipRect.height > window.innerHeight) {
                     top = rect.top - tooltipRect.height - 8;
@@ -2097,23 +2137,23 @@
                 tooltip.classList.add('hidden');
             }
         });
-        
+
         // 滚动时隐藏
         window.addEventListener('scroll', () => {
-             if (activeTarget) {
+            if (activeTarget) {
                 activeTarget = null;
                 tooltip.classList.add('hidden');
-             }
+            }
         }, true);
     }
 
     function escapeHtml(unsafe) {
         return unsafe
-             .replace(/&/g, "&amp;")
-             .replace(/</g, "&lt;")
-             .replace(/>/g, "&gt;")
-             .replace(/"/g, "&quot;")
-             .replace(/'/g, "&#039;");
+            .replace(/&/g, "&amp;")
+            .replace(/</g, "&lt;")
+            .replace(/>/g, "&gt;")
+            .replace(/"/g, "&quot;")
+            .replace(/'/g, "&#039;");
     }
 
     /**
@@ -2122,7 +2162,7 @@
     function getModelCapabilityList(model) {
         const caps = [];
         const mime = model.supportedMimeTypes || {};
-        
+
         // 1. 图片能力
         if (model.supportsImages || Object.keys(mime).some(k => k.startsWith('image/'))) {
             caps.push({
@@ -2130,7 +2170,7 @@
                 text: i18n['capability.vision'] || 'Vision'
             });
         }
-        
+
         // 2. 文档能力
         if (mime['application/pdf'] || mime['text/plain'] || mime['application/rtf']) {
             caps.push({
@@ -2138,7 +2178,7 @@
                 text: i18n['capability.docs'] || 'Documents'
             });
         }
-        
+
         // 3. 音视频能力
         if (Object.keys(mime).some(k => k.startsWith('video/') || k.startsWith('audio/'))) {
             caps.push({
@@ -2146,7 +2186,7 @@
                 text: i18n['capability.media'] || 'Media'
             });
         }
-        
+
         return caps;
     }
 
@@ -2154,7 +2194,7 @@
      * 生成能力 Tooltip HTML
      */
     function generateCapabilityTooltip(caps) {
-        return caps.map(cap => 
+        return caps.map(cap =>
             `<div class="rich-tooltip-item ${cap.className || ''}"><span class="icon">${cap.icon}</span><span class="text">${cap.text}</span></div>`
         ).join('');
     }
@@ -2163,7 +2203,7 @@
         const pct = group.remainingPercentage || 0;
         const color = getHealthColor(pct);
         const isPinned = pinnedGroups && pinnedGroups.includes(group.groupId);
-        
+
         const card = document.createElement('div');
         card.className = 'card group-card draggable';
         card.setAttribute('data-id', group.groupId);
@@ -2183,7 +2223,7 @@
             const caps = getModelCapabilityList(m);
             const tagHtml = m.tagTitle ? `<span class="tag-new">${m.tagTitle}</span>` : '';
             const recClass = m.isRecommended ? ' recommended' : '';
-            
+
             // 如果有能力，添加悬浮属性
             let tooltipAttr = '';
             let capsIndicator = '';
@@ -2232,7 +2272,7 @@
                 <div class="group-models-list">${modelList}</div>
             </div>
         `;
-        
+
         // 绑定重命名按钮事件 - 打开模态框
         const renameBtn = card.querySelector('.rename-group-btn');
         if (renameBtn) {
@@ -2245,18 +2285,18 @@
                 );
             });
         }
-        
+
         // 绑定 pin 开关事件
         const pinToggle = card.querySelector('.group-pin-toggle');
         if (pinToggle) {
             pinToggle.addEventListener('change', (e) => {
-                vscode.postMessage({ 
-                    command: 'toggleGroupPin', 
+                vscode.postMessage({
+                    command: 'toggleGroupPin',
                     groupId: group.groupId
                 });
             });
         }
-        
+
         dashboard.appendChild(card);
     }
 
@@ -2264,26 +2304,26 @@
         const pct = model.remainingPercentage || 0;
         const color = getHealthColor(pct);
         const isPinned = pinnedModels.includes(model.modelId);
-        
+
         // 获取自定义名称，如果没有则使用原始 label
         const displayName = (modelCustomNames && modelCustomNames[model.modelId]) || model.label;
         const originalLabel = model.label;
-        
+
         // 生成能力数据
         const caps = getModelCapabilityList(model);
         let capsIconHtml = '';
         let tooltipAttr = '';
-        
+
         // 如果有能力，生成标题栏图标，并设置 tooltip
         if (caps.length > 0) {
             const tooltipHtml = encodeURIComponent(generateCapabilityTooltip(caps));
             tooltipAttr = ` data-tooltip-html="${tooltipHtml}"`;
             capsIconHtml = `<span class="title-caps-trigger">✨</span>`;
         }
-        
+
         // 生成 New 标签
         const tagHtml = model.tagTitle ? `<span class="tag-new">${model.tagTitle}</span>` : '';
-        
+
         // 推荐模型高亮样式
         const recommendedClass = model.isRecommended ? ' card-recommended' : '';
 
@@ -2335,7 +2375,7 @@
                 </span>
             </div>
         `;
-        
+
         // 绑定重命名按钮事件
         const renameBtn = card.querySelector('.rename-model-btn');
         if (renameBtn) {
@@ -2344,7 +2384,7 @@
                 openModelRenameModal(model.modelId, displayName, originalLabel);
             });
         }
-        
+
         dashboard.appendChild(card);
     }
 
@@ -2404,7 +2444,7 @@
             const isUnread = announcementState.unreadIds.includes(ann.id);
             const icon = typeIcons[ann.type] || 'ℹ️';
             const timeAgo = formatTimeAgo(ann.createdAt);
-            
+
             return `
                 <div class="announcement-item ${isUnread ? 'unread' : ''}" data-id="${ann.id}">
                     <span class="announcement-icon">${icon}</span>
@@ -2462,7 +2502,7 @@
 
     function showAnnouncementPopup(ann, fromList = false) {
         currentPopupAnnouncement = ann;
-        
+
         const typeLabels = {
             feature: i18n['announcement.type.feature'] || '✨ New Feature',
             warning: i18n['announcement.type.warning'] || '⚠️ Warning',
@@ -2475,7 +2515,7 @@
         const popupContent = document.getElementById('announcement-popup-content');
         const popupAction = document.getElementById('announcement-popup-action');
         const popupGotIt = document.getElementById('announcement-popup-got-it');
-        
+
         // Header buttons
         const backBtn = document.getElementById('announcement-popup-back');
         const closeBtn = document.getElementById('announcement-popup-close');
@@ -2485,11 +2525,11 @@
             popupType.className = `announcement-type-badge ${ann.type}`;
         }
         if (popupTitle) popupTitle.textContent = ann.title;
-        
+
         // 渲染内容和图片
         if (popupContent) {
             let contentHtml = `<div class="announcement-text">${escapeHtml(ann.content).replace(/\n/g, '<br>')}</div>`;
-            
+
             // 如果有图片，渲染图片区域
             if (ann.images && ann.images.length > 0) {
                 contentHtml += '<div class="announcement-images">';
@@ -2507,9 +2547,9 @@
                 }
                 contentHtml += '</div>';
             }
-            
+
             popupContent.innerHTML = contentHtml;
-            
+
             // 绑定图片点击事件
             popupContent.querySelectorAll('.announcement-image').forEach(imgEl => {
                 imgEl.addEventListener('click', () => {
@@ -2564,24 +2604,24 @@
         const modal = document.getElementById('announcement-popup-modal');
         const modalContent = modal?.querySelector('.announcement-popup-content');
         const bellBtn = document.getElementById('announcement-btn');
-        
+
         if (modal && modalContent && bellBtn && !skipAnimation) {
             // 获取铃铛按钮的位置
             const bellRect = bellBtn.getBoundingClientRect();
             const contentRect = modalContent.getBoundingClientRect();
-            
+
             // 计算目标位移
             const targetX = bellRect.left + bellRect.width / 2 - (contentRect.left + contentRect.width / 2);
             const targetY = bellRect.top + bellRect.height / 2 - (contentRect.top + contentRect.height / 2);
-            
+
             // 添加飞向铃铛的动画
             modalContent.style.transition = 'transform 0.4s ease-in, opacity 0.4s ease-in';
             modalContent.style.transform = `translate(${targetX}px, ${targetY}px) scale(0.1)`;
             modalContent.style.opacity = '0';
-            
+
             // 铃铛抖动效果
             bellBtn.classList.add('bell-shake');
-            
+
             // 动画结束后隐藏模态框并重置样式
             setTimeout(() => {
                 modal.classList.add('hidden');
@@ -2593,15 +2633,15 @@
         } else if (modal) {
             modal.classList.add('hidden');
         }
-        
+
         currentPopupAnnouncement = null;
     }
 
     function handleAnnouncementGotIt() {
         if (currentPopupAnnouncement) {
-            vscode.postMessage({ 
-                command: 'announcement.markAsRead', 
-                id: currentPopupAnnouncement.id 
+            vscode.postMessage({
+                command: 'announcement.markAsRead',
+                id: currentPopupAnnouncement.id
             });
         }
         closeAnnouncementPopup();
@@ -2610,11 +2650,11 @@
     function handleAnnouncementAction() {
         if (currentPopupAnnouncement && currentPopupAnnouncement.action) {
             const action = currentPopupAnnouncement.action;
-            
+
             // 先标记已读
-            vscode.postMessage({ 
-                command: 'announcement.markAsRead', 
-                id: currentPopupAnnouncement.id 
+            vscode.postMessage({
+                command: 'announcement.markAsRead',
+                id: currentPopupAnnouncement.id
             });
 
             // 执行操作
@@ -2623,8 +2663,8 @@
             } else if (action.type === 'url') {
                 vscode.postMessage({ command: 'openUrl', url: action.target });
             } else if (action.type === 'command') {
-                vscode.postMessage({ 
-                    command: 'executeCommand', 
+                vscode.postMessage({
+                    command: 'executeCommand',
                     commandId: action.target,
                     commandArgs: action.arguments || []
                 });
@@ -2642,7 +2682,7 @@
         announcementState = state;
         updateAnnouncementBadge();
         renderAnnouncementList();
-        
+
         // 检查是否需要弹出公告
         if (!hasAutoPopupChecked && state.popupAnnouncement) {
             hasAutoPopupChecked = true;
@@ -2654,7 +2694,7 @@
     }
 
     // ============ 图片预览 ============
-    
+
     function showImagePreview(imageUrl) {
         // 创建预览遮罩
         const overlay = document.createElement('div');
@@ -2665,19 +2705,19 @@
                 <div class="image-preview-hint">${i18n['announcement.clickToClose'] || 'Click to close'}</div>
             </div>
         `;
-        
+
         // 点击关闭
         overlay.addEventListener('click', () => {
             overlay.classList.add('closing');
             setTimeout(() => overlay.remove(), 200);
         });
-        
+
         document.body.appendChild(overlay);
-        
+
         // 触发动画
         requestAnimationFrame(() => overlay.classList.add('visible'));
     }
-    
+
     // 暴露到 window 供 onclick 调用
     window.showImagePreview = showImagePreview;
 


### PR DESCRIPTION
## 📝 Description

This PR implements **multi-account authorization support** for the Quota Source feature. It removes the previous single-account limitation, allowing users to authorize, manage, and switch between multiple Google accounts seamlessly.

## ✨ Key Features

* **Multiple Account Authorization:** Users can now authorize and link multiple Google accounts.
* **Account Management:**
    * **List UI:** A new dashboard view displaying all authorized accounts.
    * **Add/Remove:** dedicated buttons to authorize new accounts or revoke access to existing ones.
    * **Switching:** Easily toggle which account's quota is currently being monitored.
* **Safety & Logic:**
    * **Duplicate Detection:** Prevents users from adding the same email twice.
    * **Auto-Migration:** Automatically migrates existing single-account configurations to the new multi-account data structure.
* **Localization:** All success and error messages are now bilingual (English & Chinese).

## 📸 Screenshots

<img width="1097" height="628" alt="Multi-account UI" src="https://github.com/user-attachments/assets/3e883d81-d235-48fb-8ef8-b26fcf5f9c61" />

## 🔍 Type of Change

- [ ] Bug fix
- [x] New feature
- [ ] Refactor
- [ ] Breaking change (Migration included)